### PR TITLE
Define unicode in Python 3

### DIFF
--- a/lib/utils/banner.py
+++ b/lib/utils/banner.py
@@ -5,16 +5,18 @@
 # @descr : Web Application Audit Framework
 # @author: Momo Outaadi
 
+from __future__ import print_function
+
 from lib.utils.colors import *
 
 def banner():
-	print R%1+"\t   _____       _ _ _                        "+E
-	print R%1+"\t  / ____|     | (_) |                       "+E
-	print R%1+"\t | |  __  __ _| |_| | ___  ___              "+E
-	print R%1+"\t | | |_ |/ _` | | | |/ _ \/ _ \             "+E
-	print R%1+"\t | |__| | (_| | | | |  __/ (_) |            "+E
-	print R%1+"\t  \_____|\__,_|_|_|_|\___|\___/             "+E
-	print Y%1+"\t     Web App Audit Framework              \n"+E
-	print "       -=[      Galileo v0.1.0       ]=-          "
-	print "+ ---====[    Momo Outaadi M4ll0k    ]====---- +  "
-	print "+ ---====[ https://github.com/m4ll0k ]====---- +\n"
+	print(R%1+"\t   _____       _ _ _                        "+E)
+	print(R%1+"\t  / ____|     | (_) |                       "+E)
+	print(R%1+"\t | |  __  __ _| |_| | ___  ___              "+E)
+	print(R%1+"\t | | |_ |/ _` | | | |/ _ \/ _ \             "+E)
+	print(R%1+"\t | |__| | (_| | | | |  __/ (_) |            "+E)
+	print(R%1+"\t  \_____|\__,_|_|_|_|\___|\___/             "+E)
+	print(Y%1+"\t     Web App Audit Framework              \n"+E)
+	print("       -=[      Galileo v0.1.0       ]=-          ")
+	print("+ ---====[    Momo Outaadi M4ll0k    ]====---- +  ")
+	print("+ ---====[ https://github.com/m4ll0k ]====---- +\n")

--- a/lib/utils/decoder.py
+++ b/lib/utils/decoder.py
@@ -5,9 +5,16 @@
 # @descr : Web Application Audit Framework
 # @author: Momo Outaadi
 
+try:
+	unicode        # Python 2
+except NameError:
+	unicode = str  # Python 2
+
+
 def to_str(obj):
 	if not isinstance(obj,str):
 		return str(obj)
+
 
 def to_unicode(obj):
 	if not isinstance(obj,unicode):


### PR DESCRIPTION
Fixes #3.

__unicode()__ was removed in Python 3 because all __str__ are Unicode.